### PR TITLE
fix(frontend): Clean startup of development frontend fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,14 +194,14 @@ services:
     build:
       context: frontend
       dockerfile: Dockerfile
-    user: "node"
-    working_dir: /home/node/app
     environment:
       - PORT=${DOCKER_FRONTEND_PORT}
       - REACT_APP_DOCKER_GRAFANA_HOST=fregepoc-grafana-dev
       - REACT_APP_DOCKER_GRAFANA_PORT=3000
+      - CHOKIDAR_USEPOLLING=true
     volumes:
-      - ./frontend:/home/node/app
+      - /app/node_modules
+      - ./frontend:/app
     command: npm start
     ports:
       - ${DOCKER_FRONTEND_PORT}:${DOCKER_FRONTEND_PORT}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,15 +1,15 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
-/.pnp
+**/node_modules
+**/.pnp
 .pnp.js
 
 # testing
-/coverage
+**/coverage
 
 # production
-/build
+**/build
 
 # misc
 .DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:current-alpine
+WORKDIR /app
 COPY package.json .
 COPY package-lock.json .
-RUN npm install
+RUN npm ci

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^18.1.0",
         "react-icons": "^4.4.0",
         "react-router-dom": "^6.3.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "typescript": "^4.6.3",
         "web-vitals": "^2.1.4"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,14 +11,14 @@
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.0",
     "axios": "^0.27.2",
+    "http-proxy-middleware": "^2.0.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "typescript": "^4.6.3",
-    "web-vitals": "^2.1.4",
-    "http-proxy-middleware": "^2.0.6"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This PR enables clean startup of development frontend without the need of manual npm install in the frontend directory. It shouldn't change the behaviour of the application itself. I tried to introduce as few changes as possible, but I suggest the maintainer that wants to merge this PR to pull the change and check some known user paths.