### PR TITLE
fix(backend): Missing repository cleanup after analyzer check

### DIFF
--- a/backend/fregepoc/repositories/tasks.py
+++ b/backend/fregepoc/repositories/tasks.py
@@ -158,8 +158,6 @@ def crawl_repos_task(indexer_class_name):
         )
         return
 
-    crawl_repos_task.apply_async(args=(indexer_class_name,))
-
     batch = next(iter(indexer), [])
     for repo in batch:
         repo.refresh_from_db()

--- a/backend/fregepoc/repositories/tasks.py
+++ b/backend/fregepoc/repositories/tasks.py
@@ -196,14 +196,14 @@ def process_repo_task(repo_pk):
 
             if not AnalyzerFactory.has_analyzers(language):
                 _delete_file(absolute_file_path, repo.name)
-            else:
-                file = RepositoryFile(
-                    repository=repo,
-                    repo_relative_file_path=relative_file_path,
-                    language=language,
-                    analyzed=False,
-                )
-                files.append(file)
+
+            file = RepositoryFile(
+                repository=repo,
+                repo_relative_file_path=relative_file_path,
+                language=language,
+                analyzed=False,
+            )
+            files.append(file)
 
         RepositoryFile.objects.bulk_create(files)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,8 @@ services:
       retries: 2
 
   fregepoc-loki:
-    image: grafana/loki:2.6.1
+    image: grafana/loki:2.7.4
+    user: "1000"
     container_name: fregepoc-loki
     ports:
       - 3100:3100


### PR DESCRIPTION
This should fix the known issue of the download directory getting quickly filled up #83. It could be done more in line with Celery's good practices (using callbacks or chords) but I wanted to keep it simple.