### PR TITLE
fix: add backend package to sphinx configuration

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -9,6 +9,7 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("../backend"))
 sys.path.insert(0, os.path.abspath(".."))
 
 project = "FREGE"


### PR DESCRIPTION
This is fix to [this issue](https://github.com/Software-Engineering-Jagiellonian/django-celery-frege/issues/96l).

Sphinx failed during execution of some files, because it could not find module `fregepoc`. I added path to `backend` package to `conf.py` file. This fixed most of warnings shown during documentation creation.

Now lots of additional information will appear in automatically generated documentation.