### PR TITLE
fix: Remove grafana logs (warns)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,6 @@ services:
   fregepoc-grafana-dev: &grafana
     image: grafana/grafana:8.5.2
     container_name: fregepoc-grafana-dev
-    user: root
     depends_on:
       - fregepoc-prometheus
       - fregepoc-postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,7 @@ services:
   fregepoc-grafana-dev: &grafana
     image: grafana/grafana:8.5.2
     container_name: fregepoc-grafana-dev
+    user: root
     depends_on:
       - fregepoc-prometheus
       - fregepoc-postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_USERS_ALLOW_ORG_CREATE=false
       - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_SECURITY_ALLOW_EMBEDDING=true
       - GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s:%(http_port)s/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 x-celery-healthcheck: &celery-healthcheck
   healthcheck:
     test: "celery -b redis://${DOCKER_REDIS_HOST}:${DOCKER_REDIS_PORT} inspect ping || exit 1"

--- a/grafana/provisioning/dashboards/all_collected_metrics.json
+++ b/grafana/provisioning/dashboards/all_collected_metrics.json
@@ -4,8 +4,7 @@
         {
           "builtIn": 1,
           "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
+            "type": "grafana"
           },
           "enable": true,
           "hide": true,
@@ -39,8 +38,7 @@
         "targets": [
           {
             "datasource": {
-              "type": "postgres",
-              "uid": "PA942B37CCFAF5A81"
+              "type": "postgres"
             },
             "rawQuery": true,
             "rawSql": "SELECT analyzed_time AS time, SUM(COUNT(*)) OVER (ORDER BY analyzed_time) AS analyzed_repositories FROM repositories_repository WHERE analyzed = true GROUP BY analyzed_time ORDER BY analyzed_time",
@@ -50,8 +48,7 @@
           },
           {
           "datasource": {
-            "type": "postgres",
-            "uid": "PA942B37CCFAF5A81"
+            "type": "postgres"
           },
           "rawQuery": true,
           "rawSql": "SELECT discovered_time AS time, SUM(COUNT(*)) OVER (ORDER BY discovered_time) AS all_discovered_repositories FROM repositories_repository GROUP BY discovered_time ORDER BY discovered_time",
@@ -61,8 +58,7 @@
           },
           {
           "datasource": {
-            "type": "postgres",
-            "uid": "PA942B37CCFAF5A81"
+            "type": "postgres"
           },
           "rawQuery": true,
           "rawSql": "SELECT fetch_time AS time, SUM(COUNT(*)) OVER (ORDER BY fetch_time) AS fetched_repositories FROM repositories_repository GROUP BY fetch_time ORDER BY fetch_time",
@@ -93,8 +89,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "fieldConfig": {
           "defaults": {
@@ -144,8 +139,7 @@
         "targets": [
           {
             "datasource": {
-              "type": "postgres",
-              "uid": "PA942B37CCFAF5A81"
+              "type": "postgres"
             },
             "format": "table",
             "group": [],
@@ -180,8 +174,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "fieldConfig": {
           "defaults": {
@@ -231,8 +224,7 @@
         "targets": [
           {
             "datasource": {
-              "type": "postgres",
-              "uid": "PA942B37CCFAF5A81"
+              "type": "postgres"
             },
             "format": "table",
             "group": [],
@@ -265,8 +257,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "fieldConfig": {
           "defaults": {
@@ -316,8 +307,7 @@
         "targets": [
           {
             "datasource": {
-              "type": "postgres",
-              "uid": "PA942B37CCFAF5A81"
+              "type": "postgres"
             },
             "format": "table",
             "group": [],
@@ -352,8 +342,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "fieldConfig": {
           "defaults": {
@@ -403,8 +392,7 @@
         "targets": [
           {
             "datasource": {
-              "type": "postgres",
-              "uid": "PA942B37CCFAF5A81"
+              "type": "postgres"
             },
             "format": "table",
             "group": [],
@@ -451,7 +439,6 @@
     "timepicker": {},
     "timezone": "",
     "title": "All Collected Metrics",
-    "uid": "qr5Lwn5Vk",
     "version": 1,
     "weekStart": ""
   }

--- a/grafana/provisioning/dashboards/celery_dashboard.json
+++ b/grafana/provisioning/dashboards/celery_dashboard.json
@@ -4,8 +4,7 @@
       {
         "builtIn": 1,
         "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
+          "type": "grafana"
         },
         "enable": true,
         "hide": true,
@@ -29,8 +28,7 @@
   "panels": [
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "PEBC2E3263E2CA5B6"
+        "type": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -103,8 +101,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PEBC2E3263E2CA5B6"
+            "type": "prometheus"
           },
           "expr": "flower_worker_number_of_currently_executing_tasks{}",
           "refId": "A"
@@ -115,8 +112,7 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "PEBC2E3263E2CA5B6"
+        "type": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -189,8 +185,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PEBC2E3263E2CA5B6"
+            "type": "prometheus"
           },
           "expr": "flower_task_runtime_seconds_bucket{}",
           "refId": "A"
@@ -214,7 +209,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Celery dashboard",
-  "uid": "lOxMdaunz",
   "version": 1,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/prometheus_2_stats.json
+++ b/grafana/provisioning/dashboards/prometheus_2_stats.json
@@ -4,8 +4,7 @@
         {
           "builtIn": 1,
           "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
+            "type": "datasource"
           },
           "enable": true,
           "hide": true,
@@ -48,8 +47,7 @@
     "panels": [
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -173,8 +171,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -265,8 +262,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "description": "",
         "fieldConfig": {
@@ -368,8 +364,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -447,8 +442,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -548,8 +542,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -669,8 +662,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "description": "",
         "fieldConfig": {
@@ -761,8 +753,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -873,8 +864,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "description": "",
         "fieldConfig": {
@@ -1004,8 +994,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -1103,8 +1092,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -1193,8 +1181,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -1284,8 +1271,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -1423,7 +1409,6 @@
     },
     "timezone": "browser",
     "title": "Prometheus 2.0 Stats",
-    "uid": "UDdpyzz7z",
     "version": 1,
     "weekStart": ""
   }

--- a/grafana/provisioning/dashboards/prometheus_stats.json
+++ b/grafana/provisioning/dashboards/prometheus_stats.json
@@ -4,8 +4,7 @@
         {
           "builtIn": 1,
           "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
+            "type": "datasource"
           },
           "enable": true,
           "hide": true,
@@ -49,8 +48,7 @@
     "panels": [
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -123,8 +121,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -191,8 +188,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -267,8 +263,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "editable": true,
         "error": false,
@@ -291,8 +286,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -412,8 +406,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "editable": true,
         "error": false,
@@ -436,8 +429,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -555,8 +547,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -645,8 +636,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "editable": true,
         "error": false,
@@ -669,8 +659,7 @@
       },
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PEBC2E3263E2CA5B6"
+          "type": "prometheus"
         },
         "fieldConfig": {
           "defaults": {
@@ -758,8 +747,7 @@
       },
       {
         "datasource": {
-          "type": "postgres",
-          "uid": "PA942B37CCFAF5A81"
+          "type": "postgres"
         },
         "editable": true,
         "error": false,
@@ -797,8 +785,7 @@
             "value": "fregepoc-prometheus:9090"
           },
           "datasource": {
-            "type": "prometheus",
-            "uid": "PEBC2E3263E2CA5B6"
+            "type": "prometheus"
           },
           "definition": "",
           "hide": 0,
@@ -854,7 +841,6 @@
     },
     "timezone": "browser",
     "title": "Prometheus Stats",
-    "uid": "rpfmFFz7z",
     "version": 1,
     "weekStart": ""
   }

--- a/grafana/provisioning/dashboards/redis_dashboard.json
+++ b/grafana/provisioning/dashboards/redis_dashboard.json
@@ -4,8 +4,7 @@
       {
         "builtIn": 1,
         "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
+          "type": "grafana"
         },
         "enable": true,
         "hide": true,
@@ -30,8 +29,7 @@
   "panels": [
     {
       "datasource": {
-        "type": "redis-datasource",
-        "uid": "PA7F6415749A3297A"
+        "type": "redis-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -133,8 +131,7 @@
         {
           "command": "info",
           "datasource": {
-            "type": "redis-datasource",
-            "uid": "PA7F6415749A3297A"
+            "type": "redis-datasource"
           },
           "field": "used_memory",
           "query": "",
@@ -162,7 +159,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Redis",
-  "uid": "8lpCA3unk",
   "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
When grafana container was initializing, it was given e.g. : 
- problem with duplicate uids:
```
fregepoc-grafana-dev                  | logger=provisioning.dashboard t=2025-03-16T17:51:26.04+0000 lvl=warn msg="the same UID is used more than once" orgId=1 uid=c06f16a4-b814-4cd5-a1f2-b0714ae22a66 times=2 providers="unsupported value type"
```
solution: remove uids and let grafana generate their own uids

 - problem with duplicated dashboard
```
fregepoc-grafana-dev                  | logger=provisioning.dashboard t=2025-03-16T18:54:00.88+0000 lvl=warn msg="dashboards provisioning provider has no database write permissions because of duplicates" provider="Celery dashboard" orgId=1
```
solution: no solution because grafana will be always trying to recreate dashboards even grafana volumes exist
Because its only warn log, it's probably ok

Resolves https://trello.com/c/fGCZoe3K/30-fix-grafana-logs
