### PR TITLE
log error when exception

### DIFF
--- a/backend/frege/repositories/tasks.py
+++ b/backend/frege/repositories/tasks.py
@@ -350,12 +350,12 @@ def analyze_file_task(repo_file_pk):
         for analyzer in analyzers:
             try:
                 metrics_dict |= analyzer.analyze(repo_file)
-            except Exception:
+            except Exception as e:
                 # This should use more specific exception but some analyzer is
                 # raising undocumented exceptions
                 logger.error(
                     f"Failed to analyze {repo_file.repository.git_url} for "
-                    f"analyzer {analyzer}"
+                    f"analyzer {analyzer}, error: {e}"
                 )
 
         with transaction.atomic():


### PR DESCRIPTION
```
frege-celery-worker-dev            | [2025-04-03 19:10:54,414: ERROR/ForkPoolWorker-548] frege.repositories.tasks.analyze_file_task[eeecba96-4fe5-46d7-97fe-61f216b89982]: Failed to analyze https://gitlab.com/kevintcoughlin/www.docker.io.git for analyzer <frege.analyzers.core.python.PythonAnalyzer object at 0x7fa7686b1590>, error: Missing parentheses in call to 'print'. Did you mean print(...)? (<unknown>, line 101)
```