### PR TITLE
fix: handle missing commits gracefully for empty gitlab repositories

### DIFF
--- a/backend/frege/indexers/tests/test_gitlab.py
+++ b/backend/frege/indexers/tests/test_gitlab.py
@@ -1,0 +1,109 @@
+import pytest
+from unittest.mock import patch, Mock
+from frege.indexers.utils.gitlab import Client, RateLimitExceededException
+
+@pytest.fixture
+def client():
+    return Client(token="dummy-token", min_stars=10, min_forks=5)
+
+@patch("frege.indexers.utils.gitlab.requests.get")
+def test_get_adds_token_and_checks_limit(mock_get):
+    client = Client(token="abc123", _ratelimit_remaining=1)
+    mock_response = Mock()
+    mock_response.headers = {'RateLimit-Remaining': '999'}
+    mock_get.return_value = mock_response
+
+    response = client._get("https://example.com")
+
+    assert client.ratelimit_remaining == 999
+    mock_get.assert_called_once()
+    assert mock_get.call_args[1]["headers"] == {"PRIVATE-TOKEN": "abc123"}
+    assert response == mock_response
+
+
+def test_get_raises_rate_limit():
+    client = Client(_ratelimit_remaining=0)
+    with pytest.raises(RateLimitExceededException):
+        client._get("https://example.com")
+
+
+@patch("frege.indexers.utils.gitlab.requests.get")
+def test_commit_hash_success(mock_get, client):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "commit123"}]
+    mock_get.return_value = mock_response
+
+    commit_hash = client._commit_hash(123)
+
+    assert commit_hash == "commit123"
+    mock_get.assert_called_once()
+    assert "projects/123/repository/commits" in mock_get.call_args[0][0]
+
+
+@patch("frege.indexers.utils.gitlab.requests.get")
+def test_commit_hash_empty_response(mock_get, client, caplog):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = []
+    mock_get.return_value = mock_response
+
+    with caplog.at_level("WARNING"):
+        result = client._commit_hash(456)
+
+    assert result is None
+    assert "No commits found for project 456" in caplog.text
+
+
+@patch("frege.indexers.utils.gitlab.requests.get")
+def test_commit_hash_non_200_response(mock_get, client, caplog):
+    mock_response = Mock()
+    mock_response.status_code = 403
+    mock_get.return_value = mock_response
+
+    with caplog.at_level("WARNING"):
+        result = client._commit_hash(789)
+
+    assert result is None
+    assert "Unable to fetch commits for project 789" in caplog.text
+
+
+@patch("frege.indexers.utils.gitlab.requests.get")
+def test_projects_pagination(mock_get, client):
+    response_page_1 = Mock()
+    response_page_1.json.return_value = [{"id": 1}]
+    response_page_1.links = {"next": {"url": "https://next-page.com"}}
+    response_page_1.headers = {}
+
+    response_page_2 = Mock()
+    response_page_2.json.return_value = [{"id": 2}]
+    response_page_2.links = {}
+    response_page_2.headers = {}
+
+    mock_get.side_effect = [response_page_1, response_page_2]
+
+    projects = list(client._projects())
+    flat = list(chain.from_iterable(projects))
+
+    assert [p["id"] for p in flat] == [2]
+
+
+@patch("frege.indexers.utils.gitlab.Client._get")
+@patch("frege.indexers.utils.gitlab.Client._commit_hash")
+def test_repositories_filters_and_yields(mock_commit_hash, mock_get, client):
+    mock_get.return_value = Mock(
+        json=Mock(return_value=[
+            {"id": 1, "star_count": 12, "forks_count": 6,
+             "name": "test", "description": "desc",
+             "http_url_to_repo": "git_url", "web_url": "web"}
+        ]),
+        links={}
+    )
+    mock_commit_hash.return_value = "abc123"
+
+    repos = list(client.repositories())
+    assert len(repos) == 1
+    repo_data, repo_id = repos[0]
+    assert repo_data["name"] == "test"
+    assert repo_data["commit_hash"] == "abc123"
+    assert repo_id == 1

--- a/backend/frege/indexers/utils/gitlab.py
+++ b/backend/frege/indexers/utils/gitlab.py
@@ -92,12 +92,13 @@ class Client:
         response = self._get(f"{BASE_ENDPOINT}/{project_id}/repository/commits")
 
         if response.status_code != 200:
-            logger.warning(f"Unable to fetch commits for project {project_id}, status code: {response.status_code}")
+            logger.info(f"Unable to fetch commits for project {project_id}, status code: {response.status_code}")
+            
             return None
 
         commits = response.json()
         if not commits:
-            logger.warning(f"No commits found for project {project_id}")
+            logger.info(f"No commits found for project {project_id}")
             
             return None
 

--- a/backend/frege/indexers/utils/gitlab.py
+++ b/backend/frege/indexers/utils/gitlab.py
@@ -87,8 +87,9 @@ class Client:
             yield projects_response.json()
 
     def _commit_hash(self, project_id):
-        url = f"https://gitlab.com/api/v4/projects/{project_id}/repository/commits"
-        response = self._get(url)
+        """Gets the latest commit hash in the default branch"""
+
+        response = self._get(f"{BASE_ENDPOINT}/{project_id}/repository/commits")
 
         if response.status_code != 200:
             logger.warning(f"Unable to fetch commits for project {project_id}, status code: {response.status_code}")
@@ -97,6 +98,7 @@ class Client:
         commits = response.json()
         if not commits:
             logger.warning(f"No commits found for project {project_id}")
+            
             return None
 
         return commits[0]['id']

--- a/backend/frege/indexers/utils/gitlab.py
+++ b/backend/frege/indexers/utils/gitlab.py
@@ -102,4 +102,7 @@ class Client:
             
             return None
 
-        return commits[0]['id']
+        mainBranch = commits[0]
+        hash = mainBranch['id']
+
+        return hash


### PR DESCRIPTION
During my few-day run of Frege, I noticed some issues with fetching GitLab commits:
```
frege-celery-crawl-worker-dev      | [2025-04-05 08:36:55,562: ERROR/ForkPoolWorker-1725] Task frege.repositories.tasks.crawl_repos_task[0346da6c-8c9b-426f-bb8c-ccc765862a14] raised unexpected: IndexError('list index out of range')
frege-celery-crawl-worker-dev      | Traceback (most recent call last):
frege-celery-crawl-worker-dev      |   File "/usr/local/lib/python3.13/site-packages/celery/app/trace.py", line 453, in trace_task
frege-celery-crawl-worker-dev      |     R = retval = fun(*args, **kwargs)
frege-celery-crawl-worker-dev      |                  ~~~^^^^^^^^^^^^^^^^^
frege-celery-crawl-worker-dev      |   File "/usr/local/lib/python3.13/site-packages/celery/app/trace.py", line 736, in __protected_call__
frege-celery-crawl-worker-dev      |     return self.run(*args, **kwargs)
frege-celery-crawl-worker-dev      |            ~~~~~~~~^^^^^^^^^^^^^^^^^
frege-celery-crawl-worker-dev      |   File "/usr/local/lib/python3.13/site-packages/celery/app/autoretry.py", line 38, in run
frege-celery-crawl-worker-dev      |     return task._orig_run(*args, **kwargs)
frege-celery-crawl-worker-dev      |            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
frege-celery-crawl-worker-dev      |   File "/app/frege/repositories/tasks.py", line 197, in crawl_repos_task
frege-celery-crawl-worker-dev      |     batch = next(iter(indexer), [])
frege-celery-crawl-worker-dev      |   File "/app/frege/indexers/models.py", line 221, in __iter__
frege-celery-crawl-worker-dev      |     for repo_data, _id in gitlab_client.repositories():
frege-celery-crawl-worker-dev      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
frege-celery-crawl-worker-dev      |   File "/app/frege/indexers/utils/gitlab.py", line 42, in repositories
frege-celery-crawl-worker-dev      |     commit_hash = self._commit_hash(project['id'])
frege-celery-crawl-worker-dev      |   File "/app/frege/indexers/utils/gitlab.py", line 90, in _commit_hash
frege-celery-crawl-worker-dev      |     return project_commits.json()[0]['id']
frege-celery-crawl-worker-dev      |            ~~~~~~~~~~~~~~~~~~~~~~^^^
frege-celery-crawl-worker-dev      | IndexError: list index out of range
```