### PR TITLE
add retry on celery startup

### DIFF
--- a/backend/frege/celery_app.py
+++ b/backend/frege/celery_app.py
@@ -12,6 +12,8 @@ app = Celery(
     ),
 )
 
+app.conf.broker_connection_retry_on_startup = True
+
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys


### PR DESCRIPTION
It's remedium for:
```
frege-celery-downloads-worker-dev  | [2025-04-10 18:33:36,366: WARNING/MainProcess] /usr/local/lib/python3.13/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
frege-celery-downloads-worker-dev  | whether broker connection retries are made during startup in Celery 6.0 and above.
frege-celery-downloads-worker-dev  | If you wish to retain the existing behavior for retrying connections on startup,
frege-celery-downloads-worker-dev  | you should set broker_connection_retry_on_startup to True.
```