### PR TITLE
fix: enum usage not being properly parsed by db

### DIFF
--- a/backend/frege/repositories/constants.py
+++ b/backend/frege/repositories/constants.py
@@ -1,21 +1,17 @@
 from collections.abc import Generator
 
 from django.db import models
-from enum import Enum
 
 
-class CommitMessagesTypes(Enum):
+class CommitMessagesTypes(models.TextChoices):
     FEATURE = "FEATURE"
     FIX = "FIX"
     CONFIG = "CONFIG CHANGE"
     MERGE_PR = "MERGE PR"
     UNCLASSIFIED = "UNCLASSIFIED"
-    @classmethod
-    def choices(cls):
-        return [(lang.name, lang.value) for lang in cls]
 
 
-class ProgrammingLanguages(Enum):
+class ProgrammingLanguages(models.TextChoices):
     PYTHON = "Python"
     C = "C"
     CPP = "C++"
@@ -31,9 +27,6 @@ class ProgrammingLanguages(Enum):
     SCALA = "Scala"
     SWIFT = "Swift"
     TYPESCRIPT = "TypeScript"
-    @classmethod
-    def choices(cls):
-        return [(lang.name, lang.value) for lang in cls]
 
 
 file_extensions_registry: dict[ProgrammingLanguages, list[str]] = {}


### PR DESCRIPTION
Adding `Enum` in #169 caused the frege pipeline to parse i.e. file programming language as "ProgrammingLanuages.Java" instead of "Java".

Expected:

![image](https://github.com/user-attachments/assets/c0f6fc87-3cca-4bd5-bfb0-875d59dc654d)


Current:

![image](https://github.com/user-attachments/assets/a4ec1ae1-ee8b-4e50-9809-810863363bd7)


