### PR TITLE
Grant permissions for loki container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
 
   frege-loki:
     image: grafana/loki:2.7.4
-    user: "1000"
+    user: root
     container_name: frege-loki
     ports:
       - ${DOCKER_LOKI_PORT}:${DOCKER_LOKI_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
 
   frege-loki:
     image: grafana/loki:2.7.4
+    user: root
     container_name: frege-loki
     ports:
       - ${DOCKER_LOKI_PORT}:${DOCKER_LOKI_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,6 @@ services:
 
   frege-loki:
     image: grafana/loki:2.7.4
-    user: root
     container_name: frege-loki
     ports:
       - ${DOCKER_LOKI_PORT}:${DOCKER_LOKI_PORT}


### PR DESCRIPTION
I experienced problem with failed loki container with error:
```
2025-04-24 18:52:11 mkdir /loki/rules: permission denied
2025-04-24 18:52:11 error initialising module: ruler-storage
2025-04-24 18:52:11 github.com/grafana/dskit/modules.(*Manager).initModule
2025-04-24 18:52:11     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:122
2025-04-24 18:52:11 github.com/grafana/dskit/modules.(*Manager).InitModuleServices
2025-04-24 18:52:11     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:92
2025-04-24 18:52:11 github.com/grafana/loki/pkg/loki.(*Loki).Run
2025-04-24 18:52:11     /src/loki/pkg/loki/loki.go:422
2025-04-24 18:52:11 main.main
2025-04-24 18:52:11     /src/loki/cmd/loki/main.go:105
2025-04-24 18:52:11 runtime.main
2025-04-24 18:52:11     /usr/local/go/src/runtime/proc.go:250
2025-04-24 18:52:11 runtime.goexit
2025-04-24 18:52:11     /usr/local/go/src/runtime/asm_amd64.s:1598
```