### PR TITLE
Fixing non-deterministic consumer test

### DIFF
--- a/backend/frege/repositories/tests/test_consumers.py
+++ b/backend/frege/repositories/tests/test_consumers.py
@@ -27,6 +27,12 @@ def api_key():
     _, key = APIKey.objects.create_key(name="test-key")
     return key
 
+@pytest.fixture(autouse=True)
+def use_test_channel_layer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
+    }
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 class TestLiveStatusConsumer:
@@ -45,7 +51,7 @@ class TestLiveStatusConsumer:
         api_key, request_action, create_fn, response_action, serializer
     ):
         communicator = WebsocketCommunicator(
-            LiveStatusConsumer.as_asgi(), "/ws/"
+            LiveStatusConsumer.as_asgi(), "/ws/test-live-status/"
         )
         try:
             connected, subprotocol = await communicator.connect()


### PR DESCRIPTION
## Fixed Issue with Non-Deterministic Consumer Test

Resolved an issue that was causing non-deterministic behavior in WebSocket consumer tests.

### Cause

The problem was due to using a shared `channel_layer` for message passing between application instances over WebSocket. During test execution, messages could leak between the test environment and the running application, resulting in inconsistent test outcomes.

This wasn’t an issue when the application was not running, as only the tests were using the `channel_layer`.

### Solution

The consumer tests were updated to use a separate `channel_layer`, isolating the test environment from the running application. This ensures the tests now behave deterministically and are not affected by external interference.
