### PR TITLE
Add CSRF_TRUSTED_ORIGINS and SECURE_PROXY_SSL_HEADER for reverse proxy

### DIFF
--- a/backend/frege/settings.py
+++ b/backend/frege/settings.py
@@ -16,6 +16,8 @@ SECRET_KEY = (
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
 ALLOWED_HOSTS = [os.environ.get("BACKEND_HOSTNAME"), ".localhost", "127.0.0.1"]
+CSRF_TRUSTED_ORIGINS = ["https://frege.ii.uj.edu.pl", "https://www.frege.ii.uj.edu.pl"]
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 DJANGO_CORS_ALLOWED_HOSTS = [
     os.environ.get("FRONTEND_URL", "http://localhost:4200")


### PR DESCRIPTION
## Summary
- Add `CSRF_TRUSTED_ORIGINS` for `frege.ii.uj.edu.pl` to fix CSRF 403 errors when accessing Django admin behind Apache reverse proxy
- Add `SECURE_PROXY_SSL_HEADER` so Django correctly detects HTTPS behind the proxy

## Test plan
- [x] Django admin login works at `https://frege.ii.uj.edu.pl/admin/`
- [x] No more CSRF verification failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)